### PR TITLE
Simplify array creation

### DIFF
--- a/frontend/src/sprintTable.jsx
+++ b/frontend/src/sprintTable.jsx
@@ -60,11 +60,10 @@ var SprintTable = React.createClass({
   },
 
   saveAssignees: function(index, storyId, assignees) {
-    var self = this;
-    var newAssignees = [];
-    assignees.forEach(function(assigneeId) {
-      newAssignees.push(self.getMember(assigneeId))
-    });
+    
+    var newAssignees = assignees.map(function(assigneeId) {
+      return this.getMember(assigneeId);
+    }, this);
 
     this.state.assigneeMap[storyId][index] = newAssignees;
     this.setState({assigneeMap: this.state.assigneeMap});


### PR DESCRIPTION
Wenn man nen Array braucht kann man auch `Array.map` benutzen. Und `self = this` brauch man eigentlich nie da man bei `map`, `each` etc. das `this` als zweiten parameter übergeben kann: [link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).

Das ganze könnte man noch einfacher schreiben:

```
var newAssignees = assignees.map(this.getMember, this);
```
